### PR TITLE
Add support for using host UID/GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,28 @@
-FROM sl:6
+FROM centos:6
 MAINTAINER Alexx Perloff "Alexx.Perloff@Colorado.edu"
 
 ADD cvmfs/cernvm.repo /etc/yum.repos.d/cernvm.repo
+
+RUN yum install emacs nano cvmfs man freetype openssl098e libXpm libXext wget git  tcsh zsh tcl  perl-ExtUtils-Embed perl-libwww-perl  compat-libstdc++-33  libXmu  libXpm  zip e2fsprogs krb5-devel krb5-workstation  strace libXft xdm ImageMagick ImageMagick-devel mesa-libGL mesa-libGLU glx-utils -y
+
+RUN rpm -Uvh https://www.itzgeek.com/msttcore-fonts-2.0-3.noarch.rpm
+
 ADD cvmfs/default.local /etc/cvmfs/default.local
-ADD cvmfs/run.sh /root/run.sh
-ADD cvmfs/append_to_bashrc.sh /root/.append_to_bashrc.sh
-ADD cvmfs/krb5.conf /etc/krb5.conf
 
-RUN yum update -y \
-    && yum install -y https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm \
-    && yum -y install emacs openssh-server nano cvmfs man freetype openssl098e libXpm libXext wget git  tcsh zsh tcl  perl-ExtUtils-Embed perl-libwww-perl compat-libstdc++-33 libXmu  libXpm  zip e2fsprogs krb5-devel krb5-workstation strace libXft ImageMagick ImageMagick-devel mesa-libGL mesa-libGL-devel mesa-libGLU mesa-libGLU-devel glx-utils libXrender-devel libXtst-devel xorg-x11-server-Xorg xorg-x11-xauth xorg-x11-apps openmotif openmotif-devel xz-devel \
-    && yum clean all \
-    && rm -rf /tmp/.X* \
-    && usermod -a -G root root \
-#    && ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key \
-    && cat /root/.append_to_bashrc.sh >> /root/.bashrc \
-    && mkdir .globus \
-    && chmod 0700 .globus \
-    && mkdir /cvmfs/cms.cern.ch \
-    && echo "cms.cern.ch /cvmfs/cms.cern.ch cvmfs defaults 0 0" >> /etc/fstab \
-    && mkdir /cvmfs/cms-ib.cern.ch  \
-    && echo "cms-ib.cern.ch /cvmfs/cms-ib.cern.ch cvmfs defaults 0 0" >> /etc/fstab  \
-    && mkdir /cvmfs/oasis.opensciencegrid.org  \
-    && echo "oasis.opensciencegrid.org /cvmfs/oasis.opensciencegrid.org cvmfs defaults 0 0" >> /etc/fstab  \
-    && mkdir /cvmfs/cms-lpc.opensciencegrid.org  \
-    && echo "cms-lpc.opensciencegrid.org /cvmfs/cms-lpc.opensciencegrid.org cvmfs defaults 0 0" >> /etc/fstab  \
-    && mkdir /cvmfs/sft.cern.ch \
-    && echo "sft.cern.ch /cvmfs/sft.cern.ch cvmfs defaults 0 0" >> /etc/fstab  \
-    && mkdir /cvmfs/cms-bril.cern.ch  \
-    && echo "cms-bril.cern.ch /cvmfs/cms-bril.cern.ch cvmfs defaults 0 0" >> /etc/fstab  \
-    && mkdir /cvmfs/cms-opendata-conddb.cern.ch \
-    && echo "cms-opendata-conddb.cern.ch /cvmfs/cms-opendata-conddb.cern.ch cvmfs defaults 0 0" >> /etc/fstab
+RUN for repo in cms.cern.ch cms-ib.cern.ch oasis.opensciencegrid.org \
+    cms-lpc.opensciencegrid.org sft.cern.ch cms-bri1.cern.ch cms-openddata-conddb.cern.ch; \
+     do mkdir /cvmfs/$repo; echo "$repo /cvmfs/$repo cvmfs defaults 0 0" >> /etc/fstab; \
+    done
 
-#Change the password 'cms-docker' to something unique
-#RUN echo 'root:cms-docker' |chpasswd
+RUN groupadd cmsuser && useradd -m -s /bin/bash -g cmsuser cmsuser
 
-EXPOSE 22
-ENTRYPOINT /root/run.sh && /bin/bash
+# the default limit of 1024 causes a problem if host UID == guest UID
+RUN sed -i 's/1024/8192/' /etc/security/limits.d/90-nproc.conf
+
+WORKDIR /home/cmsuser
+
+ADD cvmfs/append_to_bashrc.sh .append_to_bashrc.sh
+RUN cat .append_to_bashrc.sh >> .bashrc
+
+ADD cvmfs/run.sh /run.sh
+ENTRYPOINT ["/run.sh"]

--- a/cvmfs/run.sh
+++ b/cvmfs/run.sh
@@ -1,6 +1,31 @@
 #!/bin/bash
-mknod /dev/fuse c 10 229
-chmod a+w /dev/fuse
+
+if [ -z "$MY_UID" ]; then
+	MY_UID=$(id -u cmsuser)
+	echo "MY_UID variable not specified, defaulting to cmsuser user id ($MY_UID)"
+fi
+
+if [ -z "$MY_GID" ]; then
+	MY_GID=$(id -g cmsuser)
+	echo "MY_GID variable not specified, defaulting to cmsuser user group id ($MY_GID)"
+fi
+
+FIND_GROUP=$(grep ":$MY_GID:" /etc/group)
+
+if [ -z "$FIND_GROUP" ]; then
+	usermod -g users cmsuser
+	groupdel cmsuser
+	groupadd -g $MY_GID cmsuser
+fi
+
+# Set cmsuser account's UID.
+usermod -u $MY_UID -g $MY_GID --non-unique cmsuser > /dev/null 2>&1
+
+# Change ownership to cmsuser account on all working folders.
+chown -R $MY_UID:$MY_GID /home/cmsuser
+
+
+
 if [ -z "$CVMFS_MOUNTS" ]; then
     echo -ne "Mounting all filesystems in /etc/fstab ... "
     mount -a -F > /dev/null 2>&1
@@ -13,14 +38,6 @@ else
     done
 fi
 
-# Set the default shell as bash for docker user.
-chsh -s /bin/bash root
+#trap : TERM INT; sleep infinity & wait
+su cmsuser -s /bin/bash
 
-# restarts the xdm service
-#/etc/init.d/xdm restart
-
-# Create the directory needed to run the sshd daemon
-#mkdir /var/run/sshd
-
-# Start the ssh service
-#/usr/sbin/sshd -D

--- a/cvmfs/run.sh
+++ b/cvmfs/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+chmod o+rw /dev/fuse
+
 if [ -z "$MY_UID" ]; then
 	MY_UID=$(id -u cmsuser)
 	echo "MY_UID variable not specified, defaulting to cmsuser user id ($MY_UID)"


### PR DESCRIPTION
Run with something like:

```docker run --device /dev/fuse --cap-add SYS_ADMIN -v ~/.globus:/home/cmsuser/.globus -e CVMFS_MOUNTS="oasis.opensciencegrid.org cms.cern.ch" -e MY_UID=$(id -u) -e MY_GID=$(id -g)  --rm -name cms-cvmfs -it cms-cvmfs-docker```

If you run in the background with `-d`, attach with:

```docker attach -it -u cmsuser cms-cvmfs```