### PR TITLE
Small modification to fix Geant4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN yum install -y deltarpm \
     && yum clean all \
     && rm -rf /tmp/.X* \
     && for repo in cms.cern.ch cms-ib.cern.ch oasis.opensciencegrid.org \
-       	   cms-lpc.opensciencegrid.org sft.cern.ch cms-bril.cern.ch cms-opendata-conddb.cern.ch; \
+       	   cms-lpc.opensciencegrid.org sft.cern.ch cms-bril.cern.ch cms-opendata-conddb.cern.ch geant4.cern.ch; \
 	   do mkdir /cvmfs/$repo; echo "$repo /cvmfs/$repo cvmfs defaults 0 0" >> /etc/fstab; \
 	done \
     && groupadd cmsuser \


### PR DESCRIPTION
This change fixes Geant4 when run in the LCG environment (tested with LCG_97rc4/x86_64-centos7-gcc9-opt).