### PR TITLE
specify user for docker exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ docker rm <container name>
 
 If you find you need multiple instances withing the same container you can use the following command to open a new shell in the container:
 ```bash
-docker exec -it <container name> bash -i
+docker exec -it --user cmsusr <container name> bash -i
 ```
 
 The starting path will be `/`. Without the `-i` command the shell will start without loading any of the interactive login scripts.

--- a/cvmfs/append_to_bashrc.sh
+++ b/cvmfs/append_to_bashrc.sh
@@ -19,7 +19,7 @@ else
     	    done
         fi
     else
-        echo -e "DONE\n\tAt least one CVMFS folders is not mounted. Will automatially retry the CVMFS mounts."
+        echo -e "DONE\n\tAt least one CVMFS folders is not mounted. Will automatically retry the CVMFS mounts."
         source /mount_cvmfs.sh
         mount_cvmfs
     fi


### PR DESCRIPTION
The `.bashrc` that contains the cvmfs mounting checks etc. only runs with `docker exec` if the correct user is specified.